### PR TITLE
Add support for in-browser parsing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
           cache: "yarn"
 
       - name: Init project
-        run: yarn --frozen-lockfile
+        run: yarn --immutable
 
       - name: Webpack Build
         run: yarn build

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-nodejs 20.4.0
+nodejs 20

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "typescript.tsdk": "node_modules/typescript/lib"
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.7.0
+
+- Added support for in-browser parsing of entire simfile packs! Individual songs can be easily supported later. See [the readme](./README.md) for usage example.
+
 ## v0.6.1
 
 - Avoid publishing yarn cache in published tarball

--- a/README.md
+++ b/README.md
@@ -4,13 +4,15 @@
 
 Original parsing code from [city41/stepcharts](https://github.com/city41/stepcharts). Props to Matt for building a really sweet site.
 
-Only works in node (server-side) for now but browser support is on the radar.
+Works both in node (server-side or CLI) and in browser. Bun and Deno support is untested, but an interesting future to explore!
 
 ## Usage
 
 Install with `npm install --save simfile-parser` or `yarn add simfile-parser`
 
 ```ts
+// in node.js >= 16.9.0
+
 import {
   parseAllPacks,
   parsePack,
@@ -33,4 +35,37 @@ calculateStats(aGreatSong.charts["single-challenge"]);
   "jumps": 8,
 }
 */
+```
+
+### Browser support
+
+Support dragging packs directly into a web app by parsing in-browser!
+
+```ts
+// requires typescript 5.0 in "Bundler" module resolution mode for typings
+import { parsePack } from "simfile-parser/browser";
+
+// necessary to enable data drops
+document.body.addEventListener("dragover", function (e) {
+  e.preventDefault();
+});
+
+document.body.addEventListener("drop", async function (e) {
+  // also necessary to prevent browser navigating to dropped folder
+  evt.preventDefault();
+  if (!evt.dataTransfer) {
+    return;
+  }
+  if (evt.dataTransfer.items.length !== 1) {
+    console.error("too many items dropped, try just one folder");
+    return;
+  }
+
+  try {
+    const pack = await parsePack(evt.dataTransfer.items[0]);
+    console.log(`parsed pack "${pack.name}" with ${pack.songCount} songs`);
+  } catch (e) {
+    console.error(e);
+  }
+});
 ```

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     }
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=16.9.0"
   },
   "homepage": "https://github.com/noahm/simfile-parser#readme",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -71,9 +71,6 @@
     "ts-jest": "^29.1.1",
     "typescript": "^5.2.2"
   },
-  "peerDependencies": {
-    "@types/wicg-file-system-access": "*"
-  },
   "resolutions": {
     "semver": "^7.5.2"
   },

--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
   "main": "./dist/main.js",
   "browser": "./dist/browser/index.js",
   "types": "./dist/main.d.ts",
+  "exports": {
+    ".": "./dist/main.js",
+    "./browser": "./dist/browser/index.js"
+  },
   "bin": "./dist/cli.js",
   "sideEffects": "false",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "simfile-parser",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "Read stepmania charts with javascript!",
   "type": "module",
   "main": "./dist/main.js",
-  "browser": "./dist/browser.js",
+  "browser": "./dist/browser/index.js",
   "types": "./dist/main.d.ts",
   "bin": "./dist/cli.js",
   "sideEffects": "false",
@@ -57,6 +57,7 @@
   "devDependencies": {
     "@types/jest": "^29.5.3",
     "@types/node": "^20.4.2",
+    "@types/wicg-file-system-access": "^2023.10.1",
     "@typescript-eslint/eslint-plugin": "^6.6.0",
     "@typescript-eslint/parser": "^6.6.0",
     "confusing-browser-globals": "^1.0.11",
@@ -69,6 +70,9 @@
     "prettier": "^2.8.8",
     "ts-jest": "^29.1.1",
     "typescript": "^5.2.2"
+  },
+  "peerDependencies": {
+    "@types/wicg-file-system-access": "*"
   },
   "resolutions": {
     "semver": "^7.5.2"

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -1,1 +1,0 @@
-console.log("Sorry, no browser support yet");

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -1,6 +1,6 @@
-import { Pack, Simfile } from "../types.js";
-import { reportError, printMaybeError } from "../util.js";
-import { parseSong } from "./parseSong.js";
+import { Pack } from "../types.js";
+import { reportError } from "../util.js";
+import { BrowserSimfile, parseSong } from "./parseSong.js";
 import { isDirectoryEntry, isDirectoryHandle } from "./shared.js";
 
 /**
@@ -42,6 +42,8 @@ declare global {
     getAsFileSystemHandle?(): Promise<FileSystemHandle | null>;
   }
 }
+
+export type PackWithSongs = Pack & { simfiles: BrowserSimfile[] };
 
 /**
  * Parse a pack drag/dropped by a user in a browser
@@ -97,7 +99,7 @@ export async function parsePack(item: DataTransferItem | HTMLInputElement) {
     songCount: 0,
   };
 
-  const simfiles: Simfile[] = [];
+  const simfiles: BrowserSimfile[] = [];
   for await (const songFolder of getDirectories(dir)) {
     try {
       const songData = await parseSong(songFolder);
@@ -108,15 +110,13 @@ export async function parsePack(item: DataTransferItem | HTMLInputElement) {
         });
       }
     } catch (e) {
-      reportError(
-        `parseStepchart failed for '${songFolder.name}': ${printMaybeError(e)}`
-      );
+      reportError(`parseStepchart failed for '${songFolder.name}'`, e);
     }
   }
 
   pack.songCount = simfiles.length;
 
-  return {
+  return <PackWithSongs>{
     ...pack,
     simfiles,
   };

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -1,0 +1,123 @@
+import { Pack, Simfile } from "../types.js";
+import { reportError, printMaybeError } from "../util.js";
+import { parseSong } from "./parseSong.js";
+import { isDirectoryEntry, isDirectoryHandle } from "./shared.js";
+
+/**
+ * @param dir directory handle
+ * @yields FileSystemDirectoryHandle for each subdir of the given dir
+ * @returns nothing
+ */
+async function* getDirectories(
+  dir: FileSystemDirectoryHandle | FileSystemDirectoryEntry
+) {
+  if ("createReader" in dir) {
+    const dirs = await getDirectoriesFromEntry(dir);
+    yield* dirs;
+  } else {
+    for await (const child of dir.values()) {
+      if (child.kind === "directory") {
+        yield child;
+      }
+    }
+  }
+}
+
+/**
+ * @param dir file system entry
+ * @returns only subdirectories of the given directory
+ */
+function getDirectoriesFromEntry(dir: FileSystemDirectoryEntry) {
+  const dirReader = dir.createReader();
+  return new Promise<FileSystemDirectoryEntry[]>((resolve, reject) => {
+    dirReader.readEntries((results) => {
+      resolve(results.filter(isDirectoryEntry));
+    }, reject);
+  });
+}
+
+declare global {
+  interface DataTransferItem {
+    // optionalize this to avoid incorrect type narrowing below
+    getAsFileSystemHandle?(): Promise<FileSystemHandle | null>;
+  }
+}
+
+/**
+ * Parse a pack drag/dropped by a user in a browser
+ * @param item a DataTransferItem from a drop event
+ * @returns parsed pack
+ */
+export async function parsePack(item: DataTransferItem | HTMLInputElement) {
+  let dir: FileSystemDirectoryEntry | FileSystemDirectoryHandle;
+  if (item instanceof HTMLInputElement) {
+    if ("webkitEntries" in item) {
+      const entries = item.webkitEntries;
+      if (entries.length !== 1) {
+        throw new Error("expected exactly one selected file");
+      }
+      const entry = entries[0];
+      if (!isDirectoryEntry(entry)) {
+        throw new Error("expected folder to be dropped, but got file");
+      }
+      dir = entry;
+    } else {
+      throw new Error("entries property not available on provided input");
+    }
+  } else {
+    if (item.kind !== "file") {
+      throw new Error("expected file to be dropped, but it was not a file");
+    }
+    if (item.getAsFileSystemHandle) {
+      const dirHandle = await item.getAsFileSystemHandle();
+      if (!dirHandle) {
+        throw new Error("could not get file handle from drop item");
+      }
+      if (!isDirectoryHandle(dirHandle)) {
+        throw new Error("expected folder to be dropped, but got file");
+      }
+      dir = dirHandle;
+    } else if ("webkitGetAsEntry" in item) {
+      const entry = item.webkitGetAsEntry();
+      if (!entry) {
+        throw new Error("could not get a file entry from drop item");
+      }
+      if (!isDirectoryEntry(entry)) {
+        throw new Error("expected folder to be dropped, but got file");
+      }
+      dir = entry;
+    } else {
+      throw new Error("no supported file drop mechanism supported");
+    }
+  }
+
+  const pack: Pack = {
+    name: dir.name.replace(/-/g, " "),
+    dir: dir.name,
+    songCount: 0,
+  };
+
+  const simfiles: Simfile[] = [];
+  for await (const songFolder of getDirectories(dir)) {
+    try {
+      const songData = await parseSong(songFolder);
+      if (songData) {
+        simfiles.push({
+          ...songData,
+          pack,
+        });
+      }
+    } catch (e) {
+      reportError(
+        `parseStepchart failed for '${songFolder.name}': ${printMaybeError(e)}`
+      );
+    }
+  }
+
+  pack.songCount = simfiles.length;
+
+  return {
+    ...pack,
+    simfiles,
+  };
+}

--- a/src/browser/parseSong.ts
+++ b/src/browser/parseSong.ts
@@ -1,0 +1,194 @@
+import { parsers, supportedExtensions } from "../parsers/index.js";
+import { ParsedImages, RawSimfile } from "../parsers/types.js";
+import { Simfile } from "../types.js";
+import { extname, isFileEntry } from "./shared.js";
+
+/**
+ * Find a simfile in a given directory
+ * @param songDir directory handle
+ * @returns file handle for the song file
+ */
+async function getSongFile(
+  songDir: FileSystemDirectoryHandle | FileSystemDirectoryEntry
+) {
+  if ("createReader" in songDir) {
+    return getSongFileFromEntry(songDir);
+  }
+  for await (const handle of songDir.values()) {
+    if (handle.kind === "file") {
+      if (supportedExtensions.some((ext) => handle.name.endsWith(ext))) {
+        return handle;
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * @param songDir legacy file system entry
+ * @returns promise of the found file entry or null
+ */
+async function getSongFileFromEntry(songDir: FileSystemDirectoryEntry) {
+  const dirReader = songDir.createReader();
+  return new Promise<FileSystemFileEntry | null>((resolve, reject) => {
+    dirReader.readEntries((results) => {
+      for (const result of results) {
+        if (isFileEntry(result)) {
+          if (supportedExtensions.some((ext) => result.name.endsWith(ext))) {
+            resolve(result);
+            return;
+          }
+        }
+      }
+      resolve(null);
+    }, reject);
+  });
+}
+
+const imageExts = new Set([".png", ".jpg"]);
+
+/**
+ * Get all image files in a given directory
+ * @param songDir directory
+ * @yields file handles filtered to supported image extentions
+ */
+async function* getImages(
+  songDir: FileSystemDirectoryHandle | FileSystemDirectoryEntry
+) {
+  let files:
+    | AsyncIterable<FileSystemDirectoryHandle | FileSystemFileHandle>
+    | Iterable<FileSystemEntry>;
+  if ("values" in songDir) {
+    files = songDir.values();
+  } else {
+    files = await new Promise<FileSystemEntry[]>((res, rej) =>
+      songDir.createReader().readEntries(res, rej)
+    );
+  }
+  for await (const file of files) {
+    const ext = extname(file.name);
+    if (!ext) {
+      continue;
+    }
+    if ("kind" in file && file.kind === "directory") {
+      continue;
+    }
+    if ("isFile" in file && !isFileEntry(file)) {
+      continue;
+    }
+    if (imageExts.has(ext)) {
+      yield file as FileSystemFileEntry | FileSystemFileHandle;
+    }
+  }
+}
+
+/**
+ * Make some best guesses about which images should be used for which fields
+ * @param songDir path to a song directory
+ * @param tagged image metadata found in simfile
+ * @returns final image metadata
+ */
+async function guessImages(
+  songDir: FileSystemDirectoryHandle | FileSystemDirectoryEntry,
+  tagged: ParsedImages
+) {
+  let jacket = tagged.jacket;
+  let bg = tagged.bg;
+  let banner = tagged.banner;
+  for await (const { name: imageName } of getImages(songDir)) {
+    const ext = extname(imageName)!;
+    if (
+      (!jacket && imageName.endsWith("-jacket" + ext)) ||
+      imageName.startsWith("jacket.")
+    ) {
+      jacket = imageName;
+    }
+    if (
+      (!bg && imageName.endsWith("-bg" + ext)) ||
+      imageName.startsWith("bg.")
+    ) {
+      bg = imageName;
+    }
+    if (
+      (!banner && imageName.endsWith("-bn" + ext)) ||
+      imageName.startsWith("bn.")
+    ) {
+      banner = imageName;
+    }
+  }
+  return { jacket, bg, banner };
+}
+
+/**
+ * get individual bpms of each chart
+ * @param sm simfile
+ * @returns list of found bpms, one per chart
+ */
+function getBpms(sm: Pick<RawSimfile, "charts">): number[] {
+  const chart = Object.values(sm.charts)[0];
+  return chart.bpm.map((b) => b.bpm);
+}
+
+/**
+ * Parse a single simfile. Automatically determines which parser to use depending on chart definition type.
+ * @param songDir path to song folder (contains a chart definition file [dwi/sm], images, etc)
+ * @returns a simfile object without mix info or null if no sm/ssc file was found
+ */
+export async function parseSong(
+  songDir: FileSystemDirectoryHandle | FileSystemDirectoryEntry
+): Promise<Omit<Simfile, "mix"> | null> {
+  const songFileHandleOrEntry = await getSongFile(songDir);
+  if (!songFileHandleOrEntry) {
+    return null;
+  }
+  const extension = extname(songFileHandleOrEntry.name);
+  if (!extension) return null;
+
+  const parser = parsers[extension];
+
+  if (!parser) {
+    throw new Error(`No parser registered for extension: ${extension}`);
+  }
+
+  let fileContents: File;
+  if ("getFile" in songFileHandleOrEntry) {
+    fileContents = await songFileHandleOrEntry.getFile();
+  } else {
+    fileContents = await new Promise((resolve, reject) =>
+      songFileHandleOrEntry.file(resolve, reject)
+    );
+  }
+
+  const { images, ...rawStepchart } = parser(await fileContents.text(), "");
+
+  if (!Object.keys(rawStepchart.charts).length) {
+    throw new Error(
+      `Failed to parse any charts from song: ${rawStepchart.title}`
+    );
+  }
+
+  const bpms = getBpms(rawStepchart);
+  const minBpm = Math.round(Math.min(...bpms));
+  const maxBpm = Math.round(Math.max(...bpms));
+
+  let displayBpm = rawStepchart.displayBpm;
+  if (!displayBpm) {
+    displayBpm = minBpm === maxBpm ? minBpm.toString() : `${minBpm}-${maxBpm}`;
+  }
+
+  const finalImages = await guessImages(songDir, images);
+
+  return {
+    ...rawStepchart,
+    title: {
+      titleName: rawStepchart.title,
+      translitTitleName: rawStepchart.titletranslit ?? null,
+      titleDir: songDir.name,
+      ...finalImages,
+    },
+    minBpm,
+    maxBpm,
+    displayBpm,
+    stopCount: Object.values(rawStepchart.charts)[0].stops.length,
+  };
+}

--- a/src/browser/parseSong.ts
+++ b/src/browser/parseSong.ts
@@ -175,6 +175,7 @@ async function guessImages(
   let banner: FileRef | null = tagged.banner
     ? await guardedGetByName(songDir, tagged.banner)
     : null;
+  const leftovers: FileRef[] = [];
   for await (const image of getImages(songDir)) {
     const imageName = image.name;
     const ext = extname(imageName)!;
@@ -183,19 +184,28 @@ async function guessImages(
       imageName.startsWith("jacket.")
     ) {
       jacket = image;
-    }
-    if (
+    } else if (
       (!tagged.bg && imageName.endsWith("-bg" + ext)) ||
       imageName.startsWith("bg.")
     ) {
       bg = image;
-    }
-    if (
+    } else if (
       (!tagged.bg && imageName.endsWith("-bn" + ext)) ||
       imageName.startsWith("bn.")
     ) {
       banner = image;
+    } else {
+      leftovers.push(image);
     }
+  }
+  if (!bg && leftovers.length) {
+    bg = leftovers.shift() || null;
+  }
+  if (!banner && leftovers.length) {
+    banner = leftovers.shift() || null;
+  }
+  if (!jacket && leftovers.length) {
+    jacket = leftovers.shift() || null;
   }
   return {
     jacket: jacket ? await getFileContents(jacket) : null,

--- a/src/browser/shared.ts
+++ b/src/browser/shared.ts
@@ -1,0 +1,46 @@
+/**
+ * returns extension name from a filename
+ * @param name filename
+ * @returns extension, with leading period
+ */
+export function extname(name: string) {
+  const match = name.match(/.+(\.[^.]+)$/);
+  if (match) {
+    return match[1];
+  }
+  return null;
+}
+
+/**
+ * narrows the type of a file system entry
+ * @param handle file system entry
+ * @param handle.isFile anything
+ * @returns true if entry is a file
+ */
+export function isFileEntry(handle: {
+  isFile: boolean;
+}): handle is FileSystemFileEntry {
+  return handle.isFile;
+}
+
+/**
+ * narrows the type of a file system handle
+ * @param handle file system handle
+ * @returns true if handle is a dir
+ */
+export function isDirectoryHandle(
+  handle: FileSystemHandle
+): handle is FileSystemDirectoryHandle {
+  return handle.kind === "directory";
+}
+
+/**
+ * narrows the type of a file system handle
+ * @param handle file system handle
+ * @returns true if handle is a dir
+ */
+export function isDirectoryEntry(
+  handle: FileSystemEntry
+): handle is FileSystemDirectoryEntry {
+  return handle.isDirectory;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,7 +2,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { parseSong } from "./parseSong.js";
 import { Pack, Simfile } from "./types.js";
-import { printMaybeError, reportError } from "./util.js";
+import { reportError } from "./util.js";
 
 export * from "./types.js";
 export * from "./parseSong.js";
@@ -65,9 +65,7 @@ export function parsePack(dir: string): PackWithSongs {
         });
       }
     } catch (e) {
-      reportError(
-        `parseStepchart failed for '${songFolder}': ${printMaybeError(e)}`
-      );
+      reportError(`parseStepchart failed for '${songFolder}'`, e);
     }
   });
 

--- a/src/parseSong.ts
+++ b/src/parseSong.ts
@@ -1,31 +1,8 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { parseDwi } from "./parseDwi.js";
-import { parseSm } from "./parseSm.js";
-import { parseSsc } from "./parseSsc.js";
 import { Simfile } from "./types.js";
-
-export type RawSimfile = Omit<
-  Simfile,
-  "mix" | "title" | "minBpm" | "maxBpm"
-> & {
-  title: string;
-  titletranslit: string | null;
-  displayBpm: string | undefined;
-  images: Images;
-};
-export interface Images {
-  banner: string | null;
-  bg: string | null;
-  jacket: string | null;
-}
-type Parser = (simfileSource: string, titleDir: string) => RawSimfile;
-
-const parsers: Record<string, Parser> = {
-  ".sm": parseSm,
-  ".ssc": parseSsc,
-  ".dwi": parseDwi,
-};
+import { parsers, supportedExtensions } from "./parsers/index.js";
+import type { ParsedImages, RawSimfile } from "./parsers/types.js";
 
 /**
  * Find a simfile in a given directory
@@ -34,8 +11,7 @@ const parsers: Record<string, Parser> = {
  */
 function getSongFile(songDir: string) {
   const files = fs.readdirSync(songDir);
-  const extensions = Object.keys(parsers);
-  return files.find((f) => extensions.some((ext) => f.endsWith(ext)));
+  return files.find((f) => supportedExtensions.some((ext) => f.endsWith(ext)));
 }
 
 const imageExts = new Set([".png", ".jpg"]);
@@ -55,7 +31,7 @@ function getImages(songDir: string): string[] {
  * @param tagged image metadata found in simfile
  * @returns final image metadata
  */
-function guessImages(songDir: string, tagged: Images) {
+function guessImages(songDir: string, tagged: ParsedImages) {
   let jacket = tagged.jacket;
   let bg = tagged.bg;
   let banner = tagged.banner;

--- a/src/parseSong.ts
+++ b/src/parseSong.ts
@@ -74,7 +74,7 @@ function getBpms(sm: Pick<RawSimfile, "charts">): number[] {
  * @param songDirPath path to song folder (contains a chart definition file [dwi/sm], images, etc)
  * @returns a simfile object without mix info or null if no sm/ssc file was found
  */
-export function parseSong(songDirPath: string): Omit<Simfile, "mix"> | null {
+export function parseSong(songDirPath: string): Simfile | null {
   const songFile = getSongFile(songDirPath);
   if (!songFile) {
     return null;

--- a/src/parseSong.ts
+++ b/src/parseSong.ts
@@ -35,6 +35,7 @@ function guessImages(songDir: string, tagged: ParsedImages) {
   let jacket = tagged.jacket;
   let bg = tagged.bg;
   let banner = tagged.banner;
+  const leftovers: string[] = [];
   for (const image of getImages(songDir)) {
     const ext = path.extname(image);
     if (
@@ -42,13 +43,28 @@ function guessImages(songDir: string, tagged: ParsedImages) {
       image.startsWith("jacket.")
     ) {
       jacket = image;
-    }
-    if ((!bg && image.endsWith("-bg" + ext)) || image.startsWith("bg.")) {
+    } else if (
+      (!bg && image.endsWith("-bg" + ext)) ||
+      image.startsWith("bg.")
+    ) {
       bg = image;
-    }
-    if ((!banner && image.endsWith("-bn" + ext)) || image.startsWith("bn.")) {
+    } else if (
+      (!banner && image.endsWith("-bn" + ext)) ||
+      image.startsWith("bn.")
+    ) {
       banner = image;
+    } else {
+      leftovers.push(image);
     }
+  }
+  if (!bg && leftovers.length) {
+    bg = leftovers.shift() || null;
+  }
+  if (!banner && leftovers.length) {
+    banner = leftovers.shift() || null;
+  }
+  if (!jacket && leftovers.length) {
+    jacket = leftovers.shift() || null;
   }
   return { jacket, bg, banner };
 }

--- a/src/parsers/index.ts
+++ b/src/parsers/index.ts
@@ -1,0 +1,12 @@
+import { parseDwi } from "./parseDwi.js";
+import { parseSm } from "./parseSm.js";
+import { parseSsc } from "./parseSsc.js";
+import { Parser } from "./types.js";
+
+export const parsers: Record<string, Parser> = {
+  ".sm": parseSm,
+  ".ssc": parseSsc,
+  ".dwi": parseDwi,
+};
+
+export const supportedExtensions = Object.keys(parsers);

--- a/src/parsers/parseDwi.ts
+++ b/src/parsers/parseDwi.ts
@@ -1,14 +1,13 @@
-import fs from "node:fs";
-import { Fraction } from "./fraction.js";
-import { RawSimfile } from "./parseSong.js";
+import { Fraction } from "../fraction.js";
+import { RawSimfile } from "./types.js";
 import {
   determineBeat,
   mergeSimilarBpmRanges,
   normalizedDifficultyMap,
   printMaybeError,
   reportError,
-} from "./util.js";
-import { Arrow, FreezeLocation, BpmChange } from "./types.js";
+} from "../util.js";
+import { Arrow, FreezeLocation, BpmChange } from "../types.js";
 
 // eslint-disable-next-line jsdoc/require-jsdoc
 function isMetaTag(tag: string): tag is "title" | "artist" {
@@ -253,20 +252,6 @@ function parseArrowStream(
 }
 
 /**
- * @param titlePath path to song dir
- * @returns filename of banner, if found
- */
-function findBanner(titlePath: string): string | null {
-  const files = fs.readdirSync(titlePath);
-
-  const bannerFile = files.find(
-    (f) => f.endsWith(".png") && !f.endsWith("-bg.png")
-  );
-
-  return bannerFile ?? null;
-}
-
-/**
  * parse a DWI file
  * @param dwi entire contents of the file
  * @param titlePath path to song directory, for image discovery
@@ -287,7 +272,7 @@ export function parseDwi(dwi: string, titlePath?: string): RawSimfile {
     charts: {},
     availableTypes: [],
     images: {
-      banner: titlePath ? findBanner(titlePath) : null,
+      banner: null,
       bg: null,
       jacket: null,
     },

--- a/src/parsers/parseDwi.ts
+++ b/src/parsers/parseDwi.ts
@@ -4,7 +4,6 @@ import {
   determineBeat,
   mergeSimilarBpmRanges,
   normalizedDifficultyMap,
-  printMaybeError,
   reportError,
 } from "../util.js";
 import { Arrow, FreezeLocation, BpmChange } from "../types.js";
@@ -453,6 +452,6 @@ export function parseDwi(dwi: string, titlePath?: string): RawSimfile {
 
     return sc as RawSimfile;
   } catch (e) {
-    throw new Error(`error parsing ${dwi}\n${printMaybeError(e)}`);
+    throw new Error(`error parsing ${dwi}`, { cause: e });
   }
 }

--- a/src/parsers/parseSm.ts
+++ b/src/parsers/parseSm.ts
@@ -5,7 +5,6 @@ import {
   determineBeat,
   mergeSimilarBpmRanges,
   normalizedDifficultyMap,
-  printMaybeError,
   renameBackground,
   reportError,
 } from "../util.js";
@@ -392,8 +391,6 @@ export function parseSm(sm: string): RawSimfile {
     renameBackground(sc.images);
     return sc as RawSimfile;
   } catch (e) {
-    throw new Error(
-      `error parsing ${sm.substring(0, 300)}\n${printMaybeError(e)}`
-    );
+    throw new Error(`error parsing ${sm.substring(0, 300)}`, { cause: e });
   }
 }

--- a/src/parsers/parseSm.ts
+++ b/src/parsers/parseSm.ts
@@ -1,6 +1,6 @@
-import { Fraction } from "./fraction.js";
-import { RawSimfile } from "./parseSong.js";
-import { FreezeLocation, Arrow } from "./types.js";
+import { Fraction } from "../fraction.js";
+import { RawSimfile } from "./types.js";
+import { FreezeLocation, Arrow } from "../types.js";
 import {
   determineBeat,
   mergeSimilarBpmRanges,
@@ -8,7 +8,7 @@ import {
   printMaybeError,
   renameBackground,
   reportError,
-} from "./util.js";
+} from "../util.js";
 
 // Ref: https://github.com/stepmania/stepmania/wiki/sm
 

--- a/src/parsers/parseSsc.ts
+++ b/src/parsers/parseSsc.ts
@@ -1,12 +1,12 @@
-import { Fraction } from "./fraction.js";
-import { RawSimfile } from "./parseSong.js";
+import { Fraction } from "../fraction.js";
+import { RawSimfile } from "./types.js";
 import {
   FreezeLocation,
   Arrow,
   StepchartType,
   Stepchart,
   Mode,
-} from "./types.js";
+} from "../types.js";
 import {
   determineBeat,
   mergeSimilarBpmRanges,
@@ -14,7 +14,7 @@ import {
   printMaybeError,
   renameBackground,
   reportError,
-} from "./util.js";
+} from "../util.js";
 
 // Ref: https://github.com/stepmania/stepmania/wiki/ssc
 

--- a/src/parsers/parseSsc.ts
+++ b/src/parsers/parseSsc.ts
@@ -11,7 +11,6 @@ import {
   determineBeat,
   mergeSimilarBpmRanges,
   normalizedDifficultyMap,
-  printMaybeError,
   renameBackground,
   reportError,
 } from "../util.js";
@@ -453,8 +452,6 @@ export function parseSsc(ssc: string): RawSimfile {
     renameBackground(sc.images);
     return sc as RawSimfile;
   } catch (e) {
-    throw new Error(
-      `error parsing ${ssc.substring(0, 300)}\n${printMaybeError(e)}`
-    );
+    throw new Error(`error parsing ${ssc.substring(0, 300)}`, { cause: e });
   }
 }

--- a/src/parsers/types.ts
+++ b/src/parsers/types.ts
@@ -1,0 +1,19 @@
+import type { Simfile } from "../types.js";
+
+export type RawSimfile = Omit<
+  Simfile,
+  "mix" | "title" | "minBpm" | "maxBpm"
+> & {
+  title: string;
+  titletranslit: string | null;
+  displayBpm: string | undefined;
+  images: ParsedImages;
+};
+
+export interface ParsedImages {
+  banner: string | null;
+  bg: string | null;
+  jacket: string | null;
+}
+
+export type Parser = (simfileSource: string, titleDir: string) => RawSimfile;

--- a/src/util.ts
+++ b/src/util.ts
@@ -98,18 +98,6 @@ export function renameBackground(
   }
 }
 
-/**
- * Get a printable error string from a thing which may be an error, or may not be
- * @param e error message or other object
- * @returns printable error string
- */
-export function printMaybeError(e: any) {
-  if (e && typeof e.message === "string") {
-    return `${e.message} ${e.stack}`;
-  }
-  return "mysterious non-error";
-}
-
 let errorTolerance: "bail" | "warn" | "ignore" = "warn";
 
 /**
@@ -123,16 +111,17 @@ export function setErrorTolerance(level: typeof errorTolerance) {
 /**
  * Depending on error tolerance level this may ignore, print, or bail with a given message
  * @param msg a message to maybe print or throw
+ * @param cause an error with stack trace, if available
  */
-export function reportError(msg: string) {
+export function reportError(msg: string, cause?: unknown) {
   switch (errorTolerance) {
     case "ignore":
       break;
     case "warn":
-      console.warn(msg);
+      console.warn(msg, cause);
       break;
     case "bail":
     default:
-      throw new Error(msg);
+      throw new Error(msg, { cause });
   }
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,5 +1,5 @@
 import { Fraction } from "./fraction.js";
-import { Images } from "./parseSong.js";
+import { ParsedImages } from "./parsers/types.js";
 import { Arrow, BpmChange, Difficulty } from "./types.js";
 
 const beats = [
@@ -87,7 +87,9 @@ export function mergeSimilarBpmRanges(bpm: BpmChange[]): BpmChange[] {
  * if we found a `background` tag, rename it to `bg`
  * @param images image data
  */
-export function renameBackground(images: Images & { background?: string }) {
+export function renameBackground(
+  images: ParsedImages & { background?: string }
+) {
   if (typeof images.background !== "undefined") {
     if (images.background) {
       images.bg = images.background;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,8 +18,8 @@
     "allowSyntheticDefaultImports": true,
     "sourceMap": true,
     "outDir": "./dist/",
-    "types": ["node", "jest"],
-    "lib": ["ES2020"]
+    "types": ["node", "jest", "wicg-file-system-access"],
+    "lib": ["ES2020", "DOM"]
   },
   "include": ["src/**/*.ts"],
   "exclude": ["node_modules", "**/*.test.ts"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "ES2022",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "declaration": true,
@@ -19,7 +19,7 @@
     "sourceMap": true,
     "outDir": "./dist/",
     "types": ["node", "jest", "wicg-file-system-access"],
-    "lib": ["ES2020", "DOM"]
+    "lib": ["ES2022", "DOM"]
   },
   "include": ["src/**/*.ts"],
   "exclude": ["node_modules", "**/*.test.ts"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -4338,8 +4338,6 @@ __metadata:
     prettier: ^2.8.8
     ts-jest: ^29.1.1
     typescript: ^5.2.2
-  peerDependencies:
-    "@types/wicg-file-system-access": "*"
   bin:
     simfile-parser: ./dist/cli.js
   languageName: unknown

--- a/yarn.lock
+++ b/yarn.lock
@@ -1037,6 +1037,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/wicg-file-system-access@npm:^2023.10.1":
+  version: 2023.10.1
+  resolution: "@types/wicg-file-system-access@npm:2023.10.1"
+  checksum: 2b91ec8657a1f773c2bca40e48a19f8f8e0ebb26b882dc82ea4814cc84b9d224872fd178aa6a7462c743f32d1971727314bc56313a88b516b0e40167d6dbc8b2
+  languageName: node
+  linkType: hard
+
 "@types/yargs-parser@npm:*":
   version: 21.0.0
   resolution: "@types/yargs-parser@npm:21.0.0"
@@ -4318,6 +4325,7 @@ __metadata:
   dependencies:
     "@types/jest": ^29.5.3
     "@types/node": ^20.4.2
+    "@types/wicg-file-system-access": ^2023.10.1
     "@typescript-eslint/eslint-plugin": ^6.6.0
     "@typescript-eslint/parser": ^6.6.0
     confusing-browser-globals: ^1.0.11
@@ -4330,6 +4338,8 @@ __metadata:
     prettier: ^2.8.8
     ts-jest: ^29.1.1
     typescript: ^5.2.2
+  peerDependencies:
+    "@types/wicg-file-system-access": "*"
   bin:
     simfile-parser: ./dist/cli.js
   languageName: unknown


### PR DESCRIPTION
This adds a bunch of new codepaths to traverse in-browser filesystem structures resulting from a user's drag/drop operations or using an `<input>` element with the `webkitdirectory` attribute set.

Fixes #5 